### PR TITLE
fixed: error "Error detected while processing function <SNR><N>_detect"

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -118,7 +118,9 @@ function! s:detect() abort
     for pattern in patterns
       for neighbor in split(glob(dir.'/'.pattern), "\n")
         if neighbor !=# expand('%:p')
-          call extend(options, s:guess(readfile(neighbor, '', 1024)), 'keep')
+          if filereadable(neighbor)
+            call extend(options, s:guess(readfile(neighbor, '', 1024)), 'keep')
+          endif
         endif
         if s:apply_if_ready(options)
           return


### PR DESCRIPTION
Some files can be unreadable by a current user when traversing up
through "neighbor"-files. If so, the following error occurs:
  Error detected while processing function <SNR><N>_detect:
  line   12:
  E484: Can't open file <unreadable_filename>

To avoid this error, let's be sure we can read that file before we try
to read it.
