### PR TITLE
First check neighbours with similar extension, then try with neighbours ...

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -96,11 +96,7 @@ function! s:patterns_for(type) abort
     redir => capture
     silent autocmd BufRead
     redir END
-    let patterns = {
-          \ 'c': ['*.c'],
-          \ 'html': ['*.html'],
-          \ 'sh': ['*.sh'],
-          \ }
+    let patterns = {}
     let setfpattern = '\s\+\%(setf\%[iletype]\s\+\|set\%[local]\s\+\%(ft\|filetype\)=\|call SetFileTypeSH(["'']\%(ba\|k\)\=\%(sh\)\@=\)'
     for line in split(capture, "\n")
       let match = matchlist(line, '^\s*\(\S\+\)\='.setfpattern.'\(\w\+\)')


### PR DESCRIPTION
...with extension got from autocmd BufRead.

Hi,

For some reason the neighbours with similar extension were not searched in case of .cpp and .h files.
The patterns list in case of a .cpp file is {*.hpp, *.ipp, *.moc, ...} but *.cpp is missing.
The same is with .h files.
Maybe it is just a problem on my setup, but I don't think so, could you take a look?

Thanks,
Gabor
