### PR TITLE
Added *.h to c filetype and [*.h, *.cpp] to cpp filetype.

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -97,7 +97,8 @@ function! s:patterns_for(type) abort
     silent autocmd BufRead
     redir END
     let patterns = {
-          \ 'c': ['*.c'],
+          \ 'c': ['*.c', '*.h'],
+          \ 'cpp': ['*.cpp', '*.h'],
           \ 'html': ['*.html'],
           \ 'sh': ['*.sh'],
           \ }


### PR DESCRIPTION
Based on the conclusions of https://github.com/tpope/vim-sleuth/pull/14 this is the solution for .h and .cpp extensions.
