### PR TITLE
Added a configuration option for the default tabstop width, so it can be changed from 8

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,10 +28,14 @@ then simply copy and paste:
   the first file in a brand new Ruby project might very well be derived from
   your `.irbrc`.  I consider this a feature.
 * If your file is consistently indented with hard tabs, `'shiftwidth'` will be
-  set to your `'tabstop'`.  Otherwise, a `'tabstop'` of 8 is enforced.
+  set to your `'tabstop'`.  Otherwise, a `'tabstop'` of 8 unless configured
 * The algorithm is rolled from scratch, fairly simplistic, and only lightly
   battle tested.  It's probably not (yet) as good as [DetectIndent][].
   Let me know what it fails on for you.
+
+## Options
+* g:SleuthDefaultWidth - Change the default width from 8 to whatever you want
+
 
 ## Self-Promotion
 

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -8,6 +8,10 @@ if exists("g:loaded_sleuth") || v:version < 700 || &cp
 endif
 let g:loaded_sleuth = 1
 
+if !exists("g:SleuthDefaultWidth")
+  let g:SleuthDefaultWidth = "8"
+endif
+
 function! s:guess(lines) abort
   let options = {}
   let heuristics = {'spaces': 0, 'hard': 0, 'soft': 0}
@@ -60,7 +64,7 @@ function! s:guess(lines) abort
       let triplequote = 1
     endif
 
-    let softtab = repeat(' ', 8)
+    let softtab = repeat(' ', g:SleuthDefaultWidth)
     if line =~# '^\t'
       let heuristics.hard += 1
     elseif line =~# '^' . softtab
@@ -81,7 +85,7 @@ function! s:guess(lines) abort
   elseif heuristics.soft != heuristics.hard
     let options.expandtab = heuristics.soft > heuristics.hard
     if heuristics.hard
-      let options.tabstop = 8
+      let options.tabstop = g:SleuthDefaultWidth
     endif
   endif
 


### PR DESCRIPTION
I was not happy that the default was 8, so rather than just changing the default I kept the default at 8 and made it configurable using g:SleuthDefaultWidth, giving the user the power. I also added to the README for this change.
