### PR TITLE
Use shiftwidth 0 instead of copying tabstop

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,8 @@ then simply copy and paste:
   the first file in a brand new Ruby project might very well be derived from
   your `.irbrc`.  I consider this a feature.
 * If your file is consistently indented with hard tabs, `'shiftwidth'` will be
-  set to your `'tabstop'`.  Otherwise, a `'tabstop'` of 8 is enforced.
+  set to 0 so that `'tabstop'` is used.  Otherwise, a `'tabstop'` of 8 is
+  enforced.
 * The algorithm is rolled from scratch, fairly simplistic, and only lightly
   battle tested.  It's probably not (yet) as good as [DetectIndent][].
   Let me know what it fails on for you.

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -77,7 +77,11 @@ function! s:guess(lines) abort
   endfor
 
   if heuristics.hard && !heuristics.spaces
-    return {'expandtab': 0, 'shiftwidth': &tabstop}
+    if exists('*shiftwidth')
+      return {'expandtab': 0, 'shiftwidth': 0}
+    else
+      return {'expandtab': 0, 'shiftwidth': &tabstop}
+    endif
   elseif heuristics.soft != heuristics.hard
     let options.expandtab = heuristics.soft > heuristics.hard
     if heuristics.hard


### PR DESCRIPTION
Instead of copying the current tabstop value to shiftwidth when hard
tabs are used consistently, set shiftwidth to 0. This makes it possible
to change the tabstop value manually (e.g. for a file that is highly
indented) and shiftwidth will follow automatically.