### PR TITLE
Do not guess settings if nomodifiable

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -131,6 +131,10 @@ function! s:apply_if_ready(options) abort
 endfunction
 
 function! s:detect() abort
+  if &modifiable == 0
+    return
+  endif
+
   let options = s:guess(getline(1, 1024))
   if s:apply_if_ready(options)
     return


### PR DESCRIPTION
I noticed that when I open a vim help file I get a little lag. I profiled it and it was vm-sleuth guessing options. Since I think it is not useful to guess options for a file opened with `view` or any file in read-only mode, it seemed more general to disable based on the `modifiable` flag instead of special case the `help` filetype or make a blacklist.