### PR TITLE
optionally disable auto-detect and make globally available Detect comand

### DIFF
--- a/doc/sleuth.txt
+++ b/doc/sleuth.txt
@@ -17,4 +17,11 @@ current and parent directories.  In lieu of adjusting 'softtabstop',
                                                 *:Sleuth*
 :Sleuth                 Manually detect indentation.
 
+SETTINGS                                     *sleuth-settings*
+
+Automatic detection of buffer options can be controlled with:
+>
+  let g:sleuth_automatic = 0
+<
+
  vim:tw=78:et:ft=help:norl:

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -163,7 +163,7 @@ endif
 
 augroup sleuth
   autocmd!
-  autocmd FileType * call s:detect()
+  autocmd FileType * if get(g:, 'sleuth_automatic', 1) | call s:detect() | endif
 augroup END
 
 command! -bar -bang Sleuth call s:detect()


### PR DESCRIPTION
#35 

auto detection can be disabled by setting:

  let g:sleuth_auto_detect = 0

then detection can be run by using the

  :Detect

command manually.