### PR TITLE
Fix SleuthIndicator() for when shiftwidth is zero

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -158,12 +158,13 @@ endfunction
 setglobal smarttab
 
 function! SleuthIndicator() abort
+  let sw = &shiftwidth ? &shiftwidth : &tabstop
   if &expandtab
-    return 'sw='.&shiftwidth
-  elseif &tabstop == &shiftwidth
+    return 'sw='.sw
+  elseif &tabstop == sw
     return 'ts='.&tabstop
   else
-    return 'sw='.&shiftwidth.',ts='.&tabstop
+    return 'sw='.sw.',ts='.&tabstop
   endif
 endfunction
 


### PR DESCRIPTION
According to the vim documentation on 'shiftwidth':

    When zero the 'ts' value will be used.  Use the |shiftwidth()|
    function to get the effective shiftwidth value.

SleuthIndicator() would show `sw=0` in that case, when `&expandtab`.