### PR TITLE
Avoid opening on help files instead of unmodifiable

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -125,7 +125,7 @@ function! s:apply_if_ready(options) abort
 endfunction
 
 function! s:detect() abort
-  if &modifiable == 0
+  if &buftype ==# 'help'
     return
   endif
 


### PR DESCRIPTION
As discussed in #23, to allow proper folding of unmodifiable actual source files.