### PR TITLE
Read b:sleuth_automatic before g:sleuth_automatic.

### DIFF
--- a/doc/sleuth.txt
+++ b/doc/sleuth.txt
@@ -27,4 +27,8 @@ Automatic detection of buffer options can be controlled with:
 >
   let g:sleuth_automatic = 0
 <
+or:
+>
+  let b:sleuth_automatic = 0
+<
  vim:tw=78:et:ft=help:norl:

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -170,7 +170,9 @@ endfunction
 
 augroup sleuth
   autocmd!
-  autocmd FileType * if get(g:, 'sleuth_automatic', 1) | call s:detect() | endif
+  autocmd FileType *
+        \ if get(b:, 'sleuth_automatic', get(g:, 'sleuth_automatic', 1))
+        \ | call s:detect() | endif
   autocmd User Flags call Hoist('buffer', 5, 'SleuthIndicator')
 augroup END
 


### PR DESCRIPTION
In order to allow vim-sleuth to be selectively disabled for certain
filetypes, first try to read the sleuth_automatic configuration as a
buffer variable before reading it as a global variable.  This allows one
to set it as desired from a ftplugin.