### PR TITLE
Scan only same file

### DIFF
--- a/doc/sleuth.txt
+++ b/doc/sleuth.txt
@@ -15,16 +15,21 @@ current and parent directories.  In lieu of adjusting 'softtabstop',
 'smarttab' is enabled.
 
                                                 *:Sleuth*
-:Sleuth                 Manually detect indentation.
+:Sleuth[!]              Manually detect indentation. With ! other files are
+                        scanned as well overriding |g:sleuth_try_other_files|.
 
                                                 *SleuthIndicator()*
 SleuthIndicator()       Indicator for inclusion in 'statusline'.  Or use
                         flagship.vim to have it included automatically.
 
-SETTINGS                                     *sleuth-settings*
+SETTINGS                                        *sleuth-settings*
 
-Automatic detection of buffer options can be controlled with:
->
+Automatic detection of buffer options can be disabled with: >
   let g:sleuth_automatic = 0
+<
+
+If you want only the current file to be scanned, set: >
+  let b:sleuth_try_other_files = 0
+  let g:sleuth_try_other_files = 0
 <
  vim:tw=78:et:ft=help:norl:

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -124,7 +124,7 @@ function! s:apply_if_ready(options) abort
   endif
 endfunction
 
-function! s:detect() abort
+function! s:detect(force_try_other_files) abort
   if &buftype ==# 'help'
     return
   endif
@@ -134,7 +134,7 @@ function! s:detect() abort
     return
   endif
 
-  if get(g:, 'sleuth_try_other_files', 1)
+  if a:force_try_other_files || get(b:, 'sleuth_try_other_files', get(g:, 'sleuth_try_other_files', 1))
     let patterns = s:patterns_for(&filetype)
     call filter(patterns, 'v:val !~# "/"')
     let dir = expand('%:p:h')
@@ -153,6 +153,7 @@ function! s:detect() abort
       let dir = fnamemodify(dir, ':h')
     endwhile
   endif
+
   if has_key(options, 'shiftwidth')
     return s:apply_if_ready(extend({'expandtab': 1}, options))
   endif
@@ -173,11 +174,11 @@ endfunction
 
 augroup sleuth
   autocmd!
-  autocmd FileType * if get(g:, 'sleuth_automatic', 1) | call s:detect() | endif
+  autocmd FileType * if get(g:, 'sleuth_automatic', 1) | call s:detect(0) | endif
   autocmd User Flags call Hoist('buffer', 5, 'SleuthIndicator')
 augroup END
 
-command! -bar -bang Sleuth call s:detect()
+command! -bar -bang Sleuth call s:detect(<bang>0)
 
 if exists('g:did_indent_on')
   filetype indent off


### PR DESCRIPTION
This adds an option to scan only the current file. It also introduces `:Sleuth!` which overrides this global/buffer setting.