### PR TITLE
Don't look in / and $HOME

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -151,6 +151,11 @@ function! s:detect() abort
   call filter(patterns, 'v:val !~# "/"')
   let dir = expand('%:p:h')
   while isdirectory(dir) && dir !=# fnamemodify(dir, ':h') && c > 0
+    " the user home dir and the root dir likely contain a collection of files
+    " from different origins that do not provide any useful insight
+    if dir == expand('~') || dir == '/'
+      break
+    endif
     for pattern in patterns
       for neighbor in split(glob(dir.'/'.pattern), "\n")[0:7]
         if neighbor !=# expand('%:p') && filereadable(neighbor)


### PR DESCRIPTION
I had a script in `~/bin` and when opening it sleuth was picking an unrelated `.sh` in my home. If I had an unrelated `.sh` in `~/bin` itself this patch would not be helpful at all, but blacklisting `$HOME` and `/` seemed a sensible thing anyway as they likely contain a collection of files from different origins that do not provide any useful insight.