### PR TITLE
Heuristic tabstop for files with mostly spaces

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -133,11 +133,11 @@ function! s:Guess(source, detected, lines) abort
     if heuristics.soft
       let options.expandtab = 1
     endif
-    if heuristics.hard || has_key(a:detected.options, 'tabstop') ||
-          \ stridx(join(a:lines, "\n"), "\t") >= 0
+    if has_key(a:detected.options, 'tabstop')
       let options.tabstop = tabstop
-    elseif !&g:shiftwidth && has_key(options, 'shiftwidth') &&
-          \ !has_key(a:detected.options, 'shiftwidth')
+    elseif heuristics.spaces > heuristics.hard ||
+          \ (!&g:shiftwidth && has_key(options, 'shiftwidth') &&
+          \ !has_key(a:detected.options, 'shiftwidth'))
       let options.tabstop = options.shiftwidth
       let options.shiftwidth = 0
     endif


### PR DESCRIPTION
One common case of mixed indentation is when a file is written with mostly spaces and then unwittingly a few tabs with tabstop = shiftwidth < 8. To the author this may look perfectly regular but on another system with tabstop=8 the indentation does not line up as intended. Obviously this is broken in some sense, but in cases like this the intent is clear and we should heuristically detect the shiftwidth and set the tabstop to the same value. 

I read some of the past discussions here on mixed indents and alternate tabstop values, and I don't think this particular pattern or solution has been covered elsewhere. 

Example file that I used to observe and test this behavior: https://github.com/TheLocehiliosan/yadm/blob/e4bb8a79a4b67f447d6cdf5fda16034498a5fb27/completion/bash/yadm