### PR TITLE
Don't set softtabstop if smarttab is set

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -442,7 +442,7 @@ function! s:Apply(detected, permitted_options, silent) abort
   if !&verbose && !empty(msg) && !a:silent
     echo ':setlocal' . msg
   endif
-  if has_key(options, 'shiftwidth')
+  if !&smarttab && has_key(options, 'shiftwidth')
     let cmd .= ' softtabstop=' . (exists('*shiftwidth') ? -1 : options.shiftwidth[0])
   else
     call s:Warn(':Sleuth failed to detect indent settings', a:silent)


### PR DESCRIPTION
`smarttab` causes indentation (`<Tab>` at start of line) to exclusively use `shiftwidth`.
Setting `softtabstop=-1` is functionally equivalent to enabling `smarttab` and setting `softtabstop=shiftwidth`.

So, give the user the extra bit of flexibility of allowing `softtabstop` to differ from `shiftwidth` when `smarttab` is set. For example, I use `smarttab shiftwidth=4 softtabstop=8` to use 4 spaces for indenting, 8 spaces for alignment.