### PR TITLE
Fix editorconfig pattern parsing

### DIFF
--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -213,9 +213,9 @@ function! s:FnmatchReplace(pat) abort
     return '\%(' . join(range(matchstr(a:pat, '[+-]\=\d\+'), matchstr(a:pat, '\.\.\zs[+-]\=\d\+')), '\|') . '\)'
   elseif a:pat =~# '^{.*\\\@<!\%(\\\\\)*,.*}$'
     let done = []
-    let rest = ',' . a:pat
+    let rest = a:pat
     while !empty(rest)
-      let match = matchstr(done, '\%(\\.\|{[^\{}]*}\|[^,]\)*', 1)
+      let match = matchstr(rest, '\%(\\.\|{[^\{}]*}\|[^,\{}]\)*', 1)
       let rest = strpart(rest, len(match) + 1)
       call add(done, s:FnmatchTranslate(match))
     endwhile


### PR DESCRIPTION
Previously expressions like `*.{py,js}` were not handled correctly. This was partially caused by using the wrong variable in the `matchstr` and also required a slight regex update to handle the trailing `}`.

Through logging this function now returns:

`{js,py}` -> `\%(js\|py\)`

`{*.{c,cpp,h,h.in},Makefile,Makefile.*}` ->
`\%([^/]*\.\%(c\|cpp\|h\|h\.in\)\|Makefile\|Makefile\.[^/]*\)`

Resolves: https://github.com/tpope/vim-sleuth/issues/96