### PR TITLE
respect default settings, disable mode line and .editorconfig parsing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,30 +1,26 @@
 # sleuth.vim
 
-This plugin automatically adjusts `'shiftwidth'` and `'expandtab'`
-heuristically based on the current file, or, in the case the current file is
-new, blank, or otherwise insufficient, by looking at other files of the same
-type in the current and parent directories.  Modelines and [EditorConfig][]
-are also consulted, adding `'tabstop'`, `'textwidth'`, `'endofline'`,
-`'fileformat'`, `'fileencoding'`, and `'bomb'` to the list of supported
-options.
+This plugin adapt vim indentation to the current or neighbouring files. it will detect if spaces are used as indentation and the number of spaces.
 
-[EditorConfig]: https://editorconfig.org/
+It only changes expandtab and shiftwidth away from default values. tabstop and all other settings are left intact.
+
+ disable neighbour scanning with
+
+    :set b:sleuth_neighbor_lim=0
 
 ## Installation
 
 Install using your favorite package manager, or use Vim's built-in package
 support:
 
-    mkdir -p ~/.vim/pack/tpope/start
-    cd ~/.vim/pack/tpope/start
-    git clone https://tpope.io/vim/sleuth.git
+    mkdir -p ~/.vim/pack/abc/start
+    cd ~/.vim/pack/abc/start
+    git clone --depth=1 https://github.com/tpope/vim-sleuth
     vim -u NONE -c "helptags sleuth/doc" -c q
 
-## Notes
+If you need to modify the plugin test the changes in the same vim session with 
 
-* If your file is consistently indented with hard tabs, `'shiftwidth'` will be
-  set to your `'tabstop'`.  Otherwise, a `'tabstop'` of 8 is enforced, unless
-  another value is explicitly declared in a modeline or EditorConfig.
+    :unlet g:loaded_sleuth | w | Sleuth
 
 ## Self-Promotion
 

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -39,7 +39,7 @@ function! s:Guess(source, detected, lines) abort
   let has_heredocs = a:detected.filetype =~# '^\%(perl\|php\|ruby\|[cz]\=sh\|bash\)$'
   let options = {}
   let heuristics = {'spaces': 0, 'hard': 0, 'soft': 0, 'checked': 0, 'indents': {}}
-  let tabstop = get(a:detected.options, 'tabstop', get(a:detected.defaults, 'tabstop', [8]))[0]
+  let tabstop = get(a:detected.options, 'tabstop', get(a:detected.defaults, 'tabstop', [&tabstop]))[0]
   let softtab = repeat(' ', tabstop)
   let waiting_on = ''
   let prev_indent = -1
@@ -385,7 +385,7 @@ function! s:Ready(detected) abort
   return has_key(a:detected.options, 'expandtab') && has_key(a:detected.options, 'shiftwidth')
 endfunction
 
-let s:booleans = {'expandtab': 1, 'fixendofline': 1, 'endofline': 1, 'bomb': 1}
+let s:booleans = {'expandtab': &expandtab, 'fixendofline': &fixendofline, 'endofline': &endofline, 'bomb': &bomb}
 let s:safe_options = ['expandtab', 'shiftwidth', 'tabstop', 'textwidth', 'fixendofline']
 let s:all_options = s:safe_options + ['endofline', 'fileformat', 'fileencoding', 'bomb']
 let s:short_options = {

--- a/plugin/sleuth.vim
+++ b/plugin/sleuth.vim
@@ -385,6 +385,7 @@ function! s:Ready(detected) abort
   return has_key(a:detected.options, 'expandtab') && has_key(a:detected.options, 'shiftwidth')
 endfunction
 
+" Todo remove editor config support remove these settings
 let s:booleans = {'expandtab': &expandtab, 'fixendofline': &fixendofline, 'endofline': &endofline, 'bomb': &bomb}
 let s:safe_options = ['expandtab', 'shiftwidth', 'tabstop', 'textwidth', 'fixendofline']
 let s:all_options = s:safe_options + ['endofline', 'fileformat', 'fileencoding', 'bomb']
@@ -504,9 +505,11 @@ function! s:DetectDeclared() abort
     endif
   catch
   endtry
-  let [detected.editorconfig, detected.root] = s:DetectEditorConfig(detected.path)
-  call extend(detected.declared, s:EditorConfigToOptions(detected.editorconfig))
-  call extend(detected.declared, s:ModelineOptions())
+  " disable editor config parsing
+  " let [detected.editorconfig, detected.root] = s:DetectEditorConfig(detected.path)
+  " call extend(detected.declared, s:EditorConfigToOptions(detected.editorconfig))
+  " mode lines should already be applied 
+  " call extend(detected.declared, s:ModelineOptions())
   return detected
 endfunction
 
@@ -540,7 +543,9 @@ function! s:DetectHeuristics(into) abort
     return detected
   endif
   let dir = len(detected.path) ? fnamemodify(detected.path, ':h') : ''
-  let root = len(detected.root) ? fnamemodify(detected.root, ':h') : dir ==# s:Slash(expand('~')) ? dir : fnamemodify(dir, ':h')
+  " root is current folder
+  let root=''
+  " let root = len(detected.root) ? fnamemodify(detected.root, ':h') : dir ==# s:Slash(expand('~')) ? dir : fnamemodify(dir, ':h')
   if detected.bufname =~# '^\a\a\+:' || root ==# '.' || !isdirectory(root)
     let dir = ''
   endif


### PR DESCRIPTION
respect default settings, disable mode line and .editorconfig parsing

mode lines are already applied before plugin scripts and should not have to be parsed

todo make .editorconfig parsing optional if someone wants it. i don't want it when i am patching programs because style changes are only distracting 
